### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,17 +6,17 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-Motor KEYWORD1 Motor
+Motor	KEYWORD1	Motor
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-drive KEYWORD2
-brake KEYWORD2
-standby KEYWORD2
-left KEYWORD2
-right KEYWORD2
-forward KEYWORD2
-back KEYWORD2
+drive	KEYWORD2
+brake	KEYWORD2
+standby	KEYWORD2
+left	KEYWORD2
+right	KEYWORD2
+forward	KEYWORD2
+back	KEYWORD2
 


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords